### PR TITLE
Fixed typo for `config/bundles.php`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ composer require intervention/image-symfony
 ```
 
 After successful installation, you can activate the bundle in the file
-`config/bundes.php` of your application by inserting the following line into
+`config/bundles.php` of your application by inserting the following line into
 the array.
 
 ```php


### PR DESCRIPTION
I originally noticed this on the website https://image.intervention.io/v3/getting-started/frameworks#application-wide-configuration-1 idk if it carries over from this but I thought I'd mention it.